### PR TITLE
add support for DOCKER_PRVILEGED flag on register

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,9 +50,13 @@ grant_access_to_docker_socket() {
 configure_ci_runner() {
   if [[ ! -e ${GITLAB_CI_MULTI_RUNNER_DATA_DIR}/config.toml ]]; then
     if [[ -n ${CI_SERVER_URL} && -n ${RUNNER_TOKEN} && -n ${RUNNER_DESCRIPTION} && -n ${RUNNER_EXECUTOR} ]]; then
+      DOCKER_PRIVILEDGED_FLAG=""
+      if [ -n ${DOCKER_PRIVILEDGED} ]; then
+        DOCKER_PRIVILEDGED_FLAG="--docker-privileged"
+      fi
       sudo -HEu ${GITLAB_CI_MULTI_RUNNER_USER} \
         gitlab-ci-multi-runner register --config ${GITLAB_CI_MULTI_RUNNER_DATA_DIR}/config.toml \
-          -n -u "${CI_SERVER_URL}" -r "${RUNNER_TOKEN}" --name "${RUNNER_DESCRIPTION}" --executor "${RUNNER_EXECUTOR}"
+          -n -u "${CI_SERVER_URL}" -r "${RUNNER_TOKEN}" --name "${RUNNER_DESCRIPTION}" --executor "${RUNNER_EXECUTOR}" "${DOCKER_PRIVILEDGED_FLAG}"
     else
       sudo -HEu ${GITLAB_CI_MULTI_RUNNER_USER} \
         gitlab-ci-multi-runner register --config ${GITLAB_CI_MULTI_RUNNER_DATA_DIR}/config.toml


### PR DESCRIPTION
To allow CI runners that using docker in docker mode: http://docs.gitlab.com/ce/ci/docker/using_docker_build.html
